### PR TITLE
Add Slang::Nogil module link to META

### DIFF
--- a/META.list
+++ b/META.list
@@ -877,3 +877,4 @@ https://raw.githubusercontent.com/bbkr/HomoGlypher/master/META6.json
 https://raw.githubusercontent.com/JJ/raku-array-shaped-console/master/META6.json
 https://raw.githubusercontent.com/alabamenhu/Carp/master/META6.json
 https://raw.githubusercontent.com/ALANVF/Raku-LLVM/master/META6.json
+https://raw.githubusercontent.com/tinmarino/nogil/master/META6.json


### PR DESCRIPTION
See https://github.com/tinmarino/nogil

Add Slang::Nogil link  to META a Slang to permit scalars with no Sigil in their declaration and use:

```raku
use Slang::Nogil;
local = "value";
say local;  # OUTPUT: "value"

sub fct(param) {
    say param;
}
fct("argument");  # OUTPUT: "argument"
```

- [X] I **agree** to the usage of the META file as listed [here](https://github.com/perl6/ecosystem#legal).
- [X] Licence -> Artistic-2 in META

PS : I prefer here than CPAN because I am under active dev. 