### PR TITLE
Add Services::PortMapping to the ecosystem

### DIFF
--- a/META.list
+++ b/META.list
@@ -766,6 +766,7 @@ https://raw.githubusercontent.com/drforr/perl6-Format-Lisp/master/META6.json
 https://raw.githubusercontent.com/tony-o/perl6-digest-fnv/0.1.0/META6.json
 https://raw.githubusercontent.com/perl6-community-modules/perl6-Acme-Advent-Highlighter/master/META6.json
 https://raw.githubusercontent.com/JJ/p6-wikidata-API/master/META6.json
+https://raw.githubusercontent.com/JJ/raku-service-portmapping/master/META6.json
 https://raw.githubusercontent.com/perl6-community-modules/perl6-Proxee/master/META6.json
 https://raw.githubusercontent.com/tony-o/perl6-event-emitter-interprocess/master/META6.json
 https://raw.githubusercontent.com/gabrielash/p6-net-jupyter/master/META6.json


### PR DESCRIPTION
- [X] I **agree** to the usage of the META file as listed [here](https://github.com/perl6/ecosystem#legal).

- [X] I have a license field listed in my META file that is one of https://spdx.org/licenses
  - [ ] My license is not one of those found on spdx.org but I **do** have a license field.
        In this case make sure you have a license URL listed under support. [See this example](https://github.com/samcv/URL-Find/blob/master/META6.json).
   - [ ] I **don't** have a license field. Yes, I understand this is **not recommended**.
