### PR TITLE
Add a check for volatile source-urls

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -11,4 +11,5 @@ If adding a new module please review the following check boxes and check the app
 - [X] I have a license field listed in my META file that is one of https://spdx.org/licenses
   - [ ] My license is not one of those found on spdx.org but I **do** have a license field.
         In this case make sure you have a license URL listed under support. [See this example](https://github.com/samcv/URL-Find/blob/master/META6.json).
-   - [ ] I **don't** have a license field. Yes, I understand this is **not recommended**.
+  - [ ] I **don't** have a license field. Yes, I understand this is **not recommended**.
+- [ ] I **did not** put a volatile target in the `source-url` of the META file. Linking to a branch instead of a fixed revision or tag _will_ lead to breakage as soon as you commit to that branch.


### PR DESCRIPTION
I know of one single module that actually meets the requirement (Inline::Perl5). I'm not sure there are any others. So if this change actually reflects a best practice, then the current state of the ecosystem is grave.

So I'd like to have some feedback if this change actually _is_ a best practice. - Or if I still don't understand how the ecosystem works and just missed the point again.

Volatile `source-url`s will result in an inconsistent module state the users computer as soon as the contents of that source-url change without a matching change in the version number. Setting `source-url` to a git master branch is the typical faux-pas.
*Instead* one should change the `source-url`to link to a never changing target (a tag, revision or some zip file).

Related to [Raku/problem-solving#72](https://github.com/Raku/problem-solving/issues/72).

@niner @ugexe @JJ 