### PR TITLE
Add Generic Pod Renderer to ecosystem

### DIFF
--- a/META.list
+++ b/META.list
@@ -334,6 +334,7 @@ https://raw.githubusercontent.com/finanalyst/p6-Algorithm-Tarjan/master/META6.js
 https://raw.githubusercontent.com/finanalyst/p6-inform/master/META6.json
 https://raw.githubusercontent.com/finanalyst/p6-task-popular/master/META6.json
 https://raw.githubusercontent.com/finanalyst/pod-render/master/META6.json
+https://raw.githubusercontent.com/finanalyst/raku-pod-render/master/META6.json
 https://raw.githubusercontent.com/finanalyst/raku-pod-from-cache/master/META6.json
 https://raw.githubusercontent.com/fjwhittle/p6-Path-Map/master/META6.json
 https://raw.githubusercontent.com/gabrielash/p6-log-zmq/master/META6.json


### PR DESCRIPTION
Distribution contains Pod::To::HTML, Pod::To::MarkDown, and a Graphical README.md generator from Pod in Module file. Generates TOC and Glossary and puts them in HTML. Customisable CSS and favicon.
Implements P<> format code (old Pod::To::HTML does not do this).
Pod::To::HTML in this distribution passes all old Pod::To::HTML tests
All output determined by customisable Templates (Mustache engine but this can be changed by subclassing)
Lots of Documentation on usage and subclassing.

- [X] I **agree** to the usage of the META file as listed [here](https://github.com/Raku/ecosystem#legal).

- [X] I have a license field listed in my META file that is one of https://spdx.org/licenses
  - [ ] My license is not one of those found on spdx.org but I **do** have a license field.
        In this case make sure you have a license URL listed under support. [See this example](https://github.com/samcv/URL-Find/blob/master/META6.json).
   - [ ] I **don't** have a license field. Yes, I understand this is **not recommended**.
