### PR TITLE
Add Acme::OwO to ecosystem

### DIFF
--- a/META.list
+++ b/META.list
@@ -435,6 +435,7 @@ https://raw.githubusercontent.com/kalkin/License-Software/master/META6.json
 https://raw.githubusercontent.com/kalkin/Net-XMPP/master/META6.json
 https://raw.githubusercontent.com/kalkin/Pod-To-Latex/master/META6.json
 https://raw.githubusercontent.com/kalkin/perl6-hashids/master/META6.json
+https://raw.githubusercontent.com/kawaii/raku-acme-owo/master/META6.json
 https://raw.githubusercontent.com/khalidelboray/raku-cmark/master/META6.json
 https://raw.githubusercontent.com/khalidelboray/raku-text-slugify/master/META6.json
 https://raw.githubusercontent.com/khalidelboray/zap-api-raku/master/META6.json


### PR DESCRIPTION
<!--
Thank you for submitting a module to the Perl 6 Ecosystem!

[Uploading Perl 6 modules to CPAN](https://docs.raku.org/language/modules#Upload_your_Module_to_CPAN) is the preferred way of distributing modules, since GitHub is not a CDN. If you have the option, please use that route instead of adding the module here.

If adding a new module please review the following check boxes and check the appropriate boxes by going to the preview tab and checking them interactively or alternatively replacing the space in the checkboxes with an X. Your work is appreciated and every module helps make the Perl 6 Ecosystem a bigger and better place ♥
-->

Raku needs more Acme, and I was bored.

- [X] I **agree** to the usage of the META file as listed [here](https://github.com/Raku/ecosystem#legal).

- [X] I have a license field listed in my META file that is one of https://spdx.org/licenses
