### PR TITLE
Fix target for Bailador

### DIFF
--- a/META.list
+++ b/META.list
@@ -43,7 +43,7 @@ https://raw.githubusercontent.com/Altai-man/perl6-Text-Tabs/master/META6.json
 https://raw.githubusercontent.com/Altai-man/perl6-app-whiff/master/META6.json
 https://raw.githubusercontent.com/Altai-man/perl6-text-ldif/master/META6.json
 https://raw.githubusercontent.com/Atrox/haikunatorperl/master/META6.json
-https://raw.githubusercontent.com/Bailador/Bailador/main/META6.json
+https://raw.githubusercontent.com/Bailador/Bailador/master/META6.json
 https://raw.githubusercontent.com/codesections/pod-literate/main/META6.json
 https://raw.githubusercontent.com/codesections/pod-tangle/main/META6.json
 https://raw.githubusercontent.com/codesections/pod-weave/main/META6.json


### PR DESCRIPTION
The link to the Meta file for Bailador was adjusted to use `main` in 0294679ce9697953ebff2e0e456af61bf278e0da by @szabgab

However, currently that URL returns a 404, while the one pointing to `master` returns the correct file.
