### PR TITLE
Pod::To::Markdown has moved to CPAN

### DIFF
--- a/META.list
+++ b/META.list
@@ -729,7 +729,6 @@ https://raw.githubusercontent.com/skinkade/crypt-random/master/META6.json
 https://raw.githubusercontent.com/skinkade/p6-crypt-argon2/master/META6.json
 https://raw.githubusercontent.com/skinkade/p6-Crypt-Bcrypt/master/META6.json
 https://raw.githubusercontent.com/slobo/Perl6-X11-Xlib-Raw/master/META6.json
-https://raw.githubusercontent.com/softmoth/perl6-pod-to-markdown/master/META6.json
 https://raw.githubusercontent.com/soundart/perl6-tweetnacl/master/META6.json
 https://raw.githubusercontent.com/spebern/Parser-FreeXL-Native/master/META6.json
 https://raw.githubusercontent.com/spitsh/spitsh/master/META6.json


### PR DESCRIPTION
See https://modules.raku.org/dist/Pod::To::Markdown:cpan:SOFTMOTH