### PR TITLE
Remove AI-FANN from p6c

### DIFF
--- a/META.list
+++ b/META.list
@@ -337,7 +337,6 @@ https://raw.githubusercontent.com/JJ/raku-service-portmapping/master/META6.json
 https://raw.githubusercontent.com/JJ/raku-sys-chown/master/META6.json
 https://raw.githubusercontent.com/JJ/raku-test-script/master/META6.json
 https://raw.githubusercontent.com/JJ/raku-toi/master/META6.json
-https://raw.githubusercontent.com/jjatria/AI-FANN/master/META6.json
 https://raw.githubusercontent.com/jjatria/perl6-Pod-Parser/master/META6.json
 https://raw.githubusercontent.com/jkramer/p6-Text-Wrap/master/META6.json
 https://raw.githubusercontent.com/jnthn/grammar-debugger/master/META6.json


### PR DESCRIPTION
Development has been moved to zef, which has now seen a release
