### PR TITLE
Update META.list

### DIFF
--- a/META.list
+++ b/META.list
@@ -32,6 +32,7 @@ https://raw.githubusercontent.com/alabamenhu/IntlPromptYesNo/main/META6.json
 https://raw.githubusercontent.com/alabamenhu/IntlTokenNumber/main/META6.json
 https://raw.githubusercontent.com/alabamenhu/RegexFuzzyToken/master/META6.json
 https://raw.githubusercontent.com/alabamenhu/TestInline/master/META6.json
+https://raw.githubusercontent.com/alabamenhu/TimezonesZoneInfo/main/META6.json
 https://raw.githubusercontent.com/alabamenhu/UserLanguage/master/META6.json
 https://raw.githubusercontent.com/alabamenhu/UserTimezone/master/META6.json
 https://raw.githubusercontent.com/ALANVF/P6TK/master/META6.json


### PR DESCRIPTION
Add new Timezones::ZoneInfo module to ecosystem (required for new DateTime::Timezones module)

<!--
Thank you for submitting a module to the Perl 6 Ecosystem!

[Uploading Perl 6 modules to CPAN](https://docs.raku.org/language/modules#Upload_your_Module_to_CPAN) is the preferred way of distributing modules, since GitHub is not a CDN. If you have the option, please use that route instead of adding the module here.

If adding a new module please review the following check boxes and check the appropriate boxes by going to the preview tab and checking them interactively or alternatively replacing the space in the checkboxes with an X. Your work is appreciated and every module helps make the Perl 6 Ecosystem a bigger and better place ♥
-->

- [X] I **agree** to the usage of the META file as listed [here](https://github.com/Raku/ecosystem#legal).

- [X] I have a license field listed in my META file that is one of https://spdx.org/licenses
  - [ ] My license is not one of those found on spdx.org but I **do** have a license field.
        In this case make sure you have a license URL listed under support. [See this example](https://github.com/samcv/URL-Find/blob/master/META6.json).
   - [ ] I **don't** have a license field. Yes, I understand this is **not recommended**.
