### PR TITLE
Update a few repos from "master" to "main"

### DIFF
--- a/META.list
+++ b/META.list
@@ -226,7 +226,7 @@ https://raw.githubusercontent.com/FCO/SupplyTimeWindow/master/META6.json
 https://raw.githubusercontent.com/FCO/Test-Fuzz/master/META6.json
 https://raw.githubusercontent.com/FCO/test-time/master/META6.json
 https://raw.githubusercontent.com/FCO/Trie/master/META6.json
-https://raw.githubusercontent.com/finanalyst/collection-plugins/master/META6.json
+https://raw.githubusercontent.com/finanalyst/collection-plugins/main/META6.json
 https://raw.githubusercontent.com/finanalyst/collection-raku-documentation/master/META6.json
 https://raw.githubusercontent.com/finanalyst/p6-Algorithm-Tarjan/master/META6.json
 https://raw.githubusercontent.com/finanalyst/p6-inform/master/META6.json
@@ -267,14 +267,14 @@ https://raw.githubusercontent.com/GildedHonour/TelegramBot/master/META6.json
 https://raw.githubusercontent.com/Gnouc/p6-linux-process-signalinfo/master/META6.json
 https://raw.githubusercontent.com/goneri/p6-Email-Notmuch/master/META6.json
 https://raw.githubusercontent.com/gotoexit/Concurrent-BoundedChannel/master/META6.json
-https://raw.githubusercontent.com/grondilu/base58-raku/master/META6.json
+https://raw.githubusercontent.com/grondilu/base58-raku/main/META6.json
 https://raw.githubusercontent.com/grondilu/chess/master/META6.json
 https://raw.githubusercontent.com/grondilu/clifford/master/META6.json
 https://raw.githubusercontent.com/grondilu/Ed25519/master/META6.json
 https://raw.githubusercontent.com/grondilu/libdigest-raku/master/META6.json
 https://raw.githubusercontent.com/grondilu/openssl/master/META6.json
 https://raw.githubusercontent.com/grondilu/p6-modular/master/META.info
-https://raw.githubusercontent.com/grondilu/pbkdf2-raku/master/META6.json
+https://raw.githubusercontent.com/grondilu/pbkdf2-raku/main/META6.json
 https://raw.githubusercontent.com/grondilu/symbol/master/META6.json
 https://raw.githubusercontent.com/grondilu/trigpi/master/META6.json
 https://raw.githubusercontent.com/hankache/Acme-Cow/master/META6.json
@@ -510,7 +510,7 @@ https://raw.githubusercontent.com/prodotiscus/perl6-Dictionary-Create/master/MET
 https://raw.githubusercontent.com/raku-community-modules/Acme-Advent-Highlighter/master/META6.json
 https://raw.githubusercontent.com/raku-community-modules/ANTLR4-Grammar/master/META6.json
 https://raw.githubusercontent.com/raku-community-modules/Config-JSON/master/META6.json
-https://raw.githubusercontent.com/raku-community-modules/DBIish/master/META6.json
+https://raw.githubusercontent.com/raku-community-modules/DBIish/main/META6.json
 https://raw.githubusercontent.com/raku-community-modules/FastCGI/master/META6.json
 https://raw.githubusercontent.com/raku-community-modules/File-LibMagic/master/META6.json
 https://raw.githubusercontent.com/raku-community-modules/GD/master/META6.json
@@ -587,7 +587,7 @@ https://raw.githubusercontent.com/sergot/BreakDancer/master/META.info
 https://raw.githubusercontent.com/sergot/datetime-parse/master/META6.json
 https://raw.githubusercontent.com/sergot/http-useragent/master/META6.json
 https://raw.githubusercontent.com/sergot/io-socket-ssl/master/META6.json
-https://raw.githubusercontent.com/sergot/openssl/master/META6.json
+https://raw.githubusercontent.com/sergot/openssl/main/META6.json
 https://raw.githubusercontent.com/sergot/perl6-encode/master/META6.json
 https://raw.githubusercontent.com/sergot/Term--ProgressBar/master/META.info
 https://raw.githubusercontent.com/ShaneKilkelly/perl6-config-clever/master/META6.json


### PR DESCRIPTION
Like #598 this change is needed to make them resolve via the GraphQL API that Raku Land uses and therefore show up on [raku.land](https://raku.land).

<!--
Thank you for submitting a module to the Perl 6 Ecosystem!

[Uploading Perl 6 modules to CPAN](https://docs.raku.org/language/modules#Upload_your_Module_to_CPAN) is the preferred way of distributing modules, since GitHub is not a CDN. If you have the option, please use that route instead of adding the module here.

If adding a new module please review the following check boxes and check the appropriate boxes by going to the preview tab and checking them interactively or alternatively replacing the space in the checkboxes with an X. Your work is appreciated and every module helps make the Perl 6 Ecosystem a bigger and better place ♥
-->

- [X] I **agree** to the usage of the META file as listed [here](https://github.com/Raku/ecosystem#legal).

- [X] I have a license field listed in my META file that is one of https://spdx.org/licenses
  - [ ] My license is not one of those found on spdx.org but I **do** have a license field.
        In this case make sure you have a license URL listed under support. [See this example](https://github.com/samcv/URL-Find/blob/master/META6.json).
   - [ ] I **don't** have a license field. Yes, I understand this is **not recommended**.
