### PR TITLE
Update Ed25519 URL

### DIFF
--- a/META.list
+++ b/META.list
@@ -270,7 +270,7 @@ https://raw.githubusercontent.com/gotoexit/Concurrent-BoundedChannel/master/META
 https://raw.githubusercontent.com/grondilu/base58-raku/main/META6.json
 https://raw.githubusercontent.com/grondilu/chess/master/META6.json
 https://raw.githubusercontent.com/grondilu/clifford/master/META6.json
-https://raw.githubusercontent.com/grondilu/Ed25519/master/META6.json
+https://raw.githubusercontent.com/grondilu/ed25519-raku/main/META6.json
 https://raw.githubusercontent.com/grondilu/libdigest-raku/master/META6.json
 https://raw.githubusercontent.com/grondilu/openssl/master/META6.json
 https://raw.githubusercontent.com/grondilu/p6-modular/master/META.info


### PR DESCRIPTION
The repo has changed to from "Ed25519" to "ed25519-raku" and the default branch from "master" to "main".

<!--
Thank you for submitting a module to the Perl 6 Ecosystem!

[Uploading Perl 6 modules to CPAN](https://docs.raku.org/language/modules#Upload_your_Module_to_CPAN) is the preferred way of distributing modules, since GitHub is not a CDN. If you have the option, please use that route instead of adding the module here.

If adding a new module please review the following check boxes and check the appropriate boxes by going to the preview tab and checking them interactively or alternatively replacing the space in the checkboxes with an X. Your work is appreciated and every module helps make the Perl 6 Ecosystem a bigger and better place ♥
-->

- [X] I **agree** to the usage of the META file as listed [here](https://github.com/Raku/ecosystem#legal).

- [X] I have a license field listed in my META file that is one of https://spdx.org/licenses
  - [ ] My license is not one of those found on spdx.org but I **do** have a license field.
        In this case make sure you have a license URL listed under support. [See this example](https://github.com/samcv/URL-Find/blob/master/META6.json).
   - [ ] I **don't** have a license field. Yes, I understand this is **not recommended**.
