### PR TITLE
Time::Duration moved to fez

### DIFF
--- a/META.list
+++ b/META.list
@@ -160,7 +160,6 @@ https://raw.githubusercontent.com/cygx/p6-tinycc-resources-win64/master/META6.js
 https://raw.githubusercontent.com/cygx/p6-uni63/master/META6.json
 https://raw.githubusercontent.com/cygx/p6-unicode-gcb/master/META6.json
 https://raw.githubusercontent.com/dagurval/HTML-Strip/master/META6.json
-https://raw.githubusercontent.com/dagurval/p6-Time-Duration/master/META.info
 https://raw.githubusercontent.com/dagurval/perl6-gd-raw/master/META6.json
 https://raw.githubusercontent.com/dagurval/perl6-image-resize/master/META6.json
 https://raw.githubusercontent.com/daleevans/perl6-Text-Spintax/master/META.info


### PR DESCRIPTION
Related to the discussion of https://github.com/dagurval/p6-Time-Duration/issues/14. @masukomi has taken over the module, updated the file to META6.json among other things, and published it on the "zef ecosystem".