### PR TITLE
Remove Data::MessagePack

### DIFF
--- a/META.list
+++ b/META.list
@@ -455,7 +455,6 @@ https://gitlab.com/pheix/router-right-perl6/raw/master/META6.json
 https://raw.githubusercontent.com/pierre-vigier/Perl6-Acme-Sudoku/master/META6.json
 https://raw.githubusercontent.com/pierre-vigier/Perl6-AttrX-Lazy/master/META6.json
 https://raw.githubusercontent.com/pierre-vigier/Perl6-AttrX-PrivateAccessor/master/META6.json
-https://raw.githubusercontent.com/pierre-vigier/Perl6-Data-MessagePack/master/META6.json
 https://raw.githubusercontent.com/pierre-vigier/Perl6-HTTP-Signature/master/META6.json
 https://raw.githubusercontent.com/pierre-vigier/Perl6-Math-Matrix/master/META6.json
 https://raw.githubusercontent.com/PostCocoon/P6-TagLibC/master/META6.json


### PR DESCRIPTION
It continues its life at https://github.com/raku-community-modules/Raku-Data-MessagePack. Contributions welcome!