### PR TITLE
Remove Sustenance

### DIFF
--- a/META.list
+++ b/META.list
@@ -63,7 +63,6 @@ https://raw.githubusercontent.com/atweiden/digest-xxhash/master/META6.json
 https://raw.githubusercontent.com/atweiden/file-path-resolve/master/META6.json
 https://raw.githubusercontent.com/atweiden/file-presence/master/META6.json
 https://raw.githubusercontent.com/atweiden/mktxn/master/META6.json
-https://raw.githubusercontent.com/atweiden/sustenance/master/META6.json
 https://raw.githubusercontent.com/atweiden/txn-parser/master/META6.json
 https://raw.githubusercontent.com/atweiden/txn-remarshal/master/META6.json
 https://raw.githubusercontent.com/avuserow/perl6-audio-taglib-simple/master/META6.json


### PR DESCRIPTION
Because it is providing almost daily updates without ever increasing the version number, causing false positives in updates and etc.

The REA contains an older version of Sustenance, so people will still be able to install it.