### PR TITLE
Remove WebService::AWS::Auth::V4

### DIFF
--- a/META.list
+++ b/META.list
@@ -92,7 +92,6 @@ https://raw.githubusercontent.com/bluebear94/Math-Random/master/META6.json
 https://raw.githubusercontent.com/bluebear94/Terminal-WCWidth/master/META6.json
 https://raw.githubusercontent.com/bradclawsie/Context/master/META6.json
 https://raw.githubusercontent.com/bradclawsie/DB-Rscs/master/META6.json
-https://raw.githubusercontent.com/bradclawsie/WebService-AWS-Auth-V4/master/META6.json
 https://raw.githubusercontent.com/briandfoy/perl6-chemistry-elements/master/META6.json
 https://raw.githubusercontent.com/briandfoy/perl6-PrettyDump/master/META6.json
 https://raw.githubusercontent.com/byterock/Acme-Flutterby/master/META.info


### PR DESCRIPTION
It lives on the zef ecosystem now.