### PR TITLE
Remove LibraryMake

### DIFF
--- a/META.list
+++ b/META.list
@@ -479,7 +479,6 @@ https://raw.githubusercontent.com/retupmoca/p6-Crust-Handler-SCGI/master/META6.j
 https://raw.githubusercontent.com/retupmoca/p6-Crust-Middleware-Syslog/master/META6.json
 https://raw.githubusercontent.com/retupmoca/P6-HTTP-ParseParams/master/META6.json
 https://raw.githubusercontent.com/retupmoca/P6-iCal/master/META6.json
-https://raw.githubusercontent.com/retupmoca/P6-LibraryMake/master/META6.json
 https://raw.githubusercontent.com/retupmoca/p6-MIME-QuotedPrint/master/META6.json
 https://raw.githubusercontent.com/retupmoca/P6-Net-AMQP/master/META6.json
 https://raw.githubusercontent.com/retupmoca/P6-Net-POP3/master/META6.json


### PR DESCRIPTION
Now it lives on the zef ecosystem JJ++
