### PR TITLE
Remove GlotIO

### DIFF
--- a/META.list
+++ b/META.list
@@ -443,7 +443,6 @@ https://raw.githubusercontent.com/raku-community-modules/Config-JSON/master/META
 https://raw.githubusercontent.com/raku-community-modules/FastCGI/master/META6.json
 https://raw.githubusercontent.com/raku-community-modules/File-LibMagic/master/META6.json
 https://raw.githubusercontent.com/raku-community-modules/GD/master/META6.json
-https://raw.githubusercontent.com/raku-community-modules/GlotIO/master/META6.json
 https://raw.githubusercontent.com/raku-community-modules/Inline-Scheme-Guile/master/META6.json
 https://raw.githubusercontent.com/raku-community-modules/IRC-Client-Plugin-Factoid/master/META6.json
 https://raw.githubusercontent.com/raku-community-modules/Reminders/master/META6.json


### PR DESCRIPTION
It has been revived and is now living in zef's ecosystem