### PR TITLE
Removing one of the Fcntl repos

### DIFF
--- a/META.list
+++ b/META.list
@@ -308,7 +308,6 @@ https://raw.githubusercontent.com/khalidelboray/Pastebin-Pasteee/main/META6.json
 https://raw.githubusercontent.com/khalidelboray/raku-cmark/master/META6.json
 https://raw.githubusercontent.com/khalidelboray/raku-text-slugify/master/META6.json
 https://raw.githubusercontent.com/khalidelboray/zap-api-raku/master/META6.json
-https://raw.githubusercontent.com/kjkuan/perl6-Fcntl/master/META6.json
 https://raw.githubusercontent.com/kjkuan/Proc-Feed/master/META6.json
 https://raw.githubusercontent.com/kmwallio/Acme-Skynet/master/META6.json
 https://raw.githubusercontent.com/kmwallio/p6-Lingua-EN-Stopwords/master/META6.json


### PR DESCRIPTION
Perhaps both would be good to go.
This one was a fork of fork of the other one, more lagging behind than the original one. The original one is released both here and on CPAN. The only known module that might have depended on this (Shell::DSL) didn't have the metadata pinned so even that was already retrieving the other one.