### PR TITLE
Remove old HTML::Tag

### DIFF
--- a/META.list
+++ b/META.list
@@ -2,7 +2,6 @@ https://raw.githubusercontent.com/7ojo/p6-commandline-usage/master/META6.json
 https://raw.githubusercontent.com/7ojo/perl6-git-simple/master/META6.json
 https://raw.githubusercontent.com/7ojo/perl6-powerline-prompt/master/META6.json
 https://raw.githubusercontent.com/adaptiveoptics/Crust-Middleware-Session-Store-DBIish/master/META6.json
-https://raw.githubusercontent.com/adaptiveoptics/HTML-Tag/master/META6.json
 https://raw.githubusercontent.com/adaptiveoptics/P6-Finance-GDAX-API/master/META6.json
 https://raw.githubusercontent.com/adaptiveoptics/P6-Prompt-Gruff/master/META6.json
 https://raw.githubusercontent.com/afiskon/p6-datetime-format-w3cdtf/master/META6.json


### PR DESCRIPTION
I'm inclined to think this can be removed.
https://github.com/adaptiveoptics/HTML-Tag/issues/3 I maintain this distribution as my own, for all intents and purposes. It shouldn't be considered still available. It will still on REA from what I understand so nothing breaks but no new code should use it.