### PR TITLE
Remove DateTime::Timezones

### DIFF
--- a/META.list
+++ b/META.list
@@ -11,7 +11,6 @@ https://raw.githubusercontent.com/ajs/perl6-Math-Arrow/master/META6.json
 https://raw.githubusercontent.com/ajs/perl6-Math-Sequences/master/META6.json
 https://raw.githubusercontent.com/akiym/JSON-Hjson/master/META6.json
 https://raw.githubusercontent.com/alabamenhu/Carp/master/META6.json
-https://raw.githubusercontent.com/alabamenhu/DateTimeTimezones/master/META6.json
 https://raw.githubusercontent.com/alabamenhu/DebugTransput/main/META6.json
 https://raw.githubusercontent.com/alabamenhu/Fluent/master/META6.json
 https://raw.githubusercontent.com/alabamenhu/IntlFormatList/main/META6.json


### PR DESCRIPTION
It has been living on zef for quite a while.
https://raku.land/zef:guifa/DateTime::Timezones