### PR TITLE
remove my modules

### DIFF
--- a/META.list
+++ b/META.list
@@ -471,12 +471,6 @@ https://raw.githubusercontent.com/shuppet/raku-mint/main/META6.json
 https://raw.githubusercontent.com/sirrobert/Class-Utils/master/META6.json
 https://raw.githubusercontent.com/sirrobert/Masquerade/master/META6.json
 https://raw.githubusercontent.com/sirrobert/Semantic-Versioning/master/META6.json
-https://raw.githubusercontent.com/skaji/App-P6Ghq/master/META6.json
-https://raw.githubusercontent.com/skaji/Data-Section-Simple/master/META6.json
-https://raw.githubusercontent.com/skaji/Frinfon/master/META6.json
-https://raw.githubusercontent.com/skaji/perl6-MetaCPAN-Favorite/master/META6.json
-https://raw.githubusercontent.com/skaji/perl6-tail/master/META6.json
-https://raw.githubusercontent.com/skaji/perl6-WaitGroup/master/META6.json
 https://raw.githubusercontent.com/Skarsnik/acme-wtf/master/META6.json
 https://raw.githubusercontent.com/Skarsnik/gptrixie/master/META6.json
 https://raw.githubusercontent.com/Skarsnik/nativecall-typediag/master/META6.json


### PR DESCRIPTION
I don't think I will actively maintain these modules anymore.
So I think it's fine to simply remove them.

Of course, if someone want to use these modules, then just install them from github.com directly:

```
zef install https://github.com/skaji/foo-module.git
```

---
<!--
Thank you for submitting a module to the Perl 6 Ecosystem!

[Uploading Perl 6 modules to CPAN](https://docs.raku.org/language/modules#Upload_your_Module_to_CPAN) is the preferred way of distributing modules, since GitHub is not a CDN. If you have the option, please use that route instead of adding the module here.

If adding a new module please review the following check boxes and check the appropriate boxes by going to the preview tab and checking them interactively or alternatively replacing the space in the checkboxes with an X. Your work is appreciated and every module helps make the Perl 6 Ecosystem a bigger and better place ♥
-->

- [X] I **agree** to the usage of the META file as listed [here](https://github.com/Raku/ecosystem#legal).

- [X] I have a license field listed in my META file that is one of https://spdx.org/licenses
  - [ ] My license is not one of those found on spdx.org but I **do** have a license field.
        In this case make sure you have a license URL listed under support. [See this example](https://github.com/samcv/URL-Find/blob/master/META6.json).
   - [ ] I **don't** have a license field. Yes, I understand this is **not recommended**.
